### PR TITLE
Recreate documentation

### DIFF
--- a/docs/data-sources/recordset.md
+++ b/docs/data-sources/recordset.md
@@ -37,15 +37,13 @@ data "powerdns_recordset" "example_net_soa" {
 
 ### Required
 
-- **name** (String) Name for record set (e.g. "www.powerdns.com.")
-- **server_id** (String) The id of the server.
-- **type** (String) Type of this record (e.g. "A", "PTR", "MX"). Required if record name is not unique.
-- **zone_id** (String) ID of the zone this record set belongs to.
+- `name` (String) Name for record set (e.g. "www.powerdns.com.")
+- `server_id` (String) The id of the server.
+- `type` (String) Type of this record (e.g. "A", "PTR", "MX"). Required if record name is not unique.
+- `zone_id` (String) ID of the zone this record set belongs to.
 
 ### Read-Only
 
-- **id** (String) State ID for the record set (only needed for internal technical purposes).
-- **records** (List of String) All records in this record set.
-- **ttl** (Number) DNS TTL of the records, in seconds.
-
-
+- `id` (String) State ID for the record set (only needed for internal technical purposes).
+- `records` (List of String) All records in this record set.
+- `ttl` (Number) DNS TTL of the records, in seconds.

--- a/docs/data-sources/zone.md
+++ b/docs/data-sources/zone.md
@@ -24,12 +24,10 @@ data "powerdns_zone" "example_net" {
 
 ### Required
 
-- **id** (String) Opaque zone id, assigned by the server.
-- **server_id** (String) The id of the server.
+- `id` (String) Opaque zone id, assigned by the server.
+- `server_id` (String) The id of the server.
 
 ### Read-Only
 
-- **kind** (String) Zone kind, one of "Native", "Master", "Slave".
-- **name** (String) Name of the zone (e.g. "example.com.") MUST have a trailing dot.
-
-
+- `kind` (String) Zone kind, one of "Native", "Master", "Slave".
+- `name` (String) Name of the zone (e.g. "example.com.") MUST have a trailing dot.

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,5 +24,5 @@ provider "powerdns" {
 
 ### Optional
 
-- **api_key** (String, Sensitive) PowerDNS API key for authentication. Can be set via environment variable `POWERDNS_API_KEY`.
-- **server_url** (String) PowerDNS server URL. Can be set via environment variable `POWERDNS_SERVER_URL`.
+- `api_key` (String, Sensitive) PowerDNS API key for authentication. Can be set via environment variable `POWERDNS_API_KEY`.
+- `server_url` (String) PowerDNS server URL. Can be set via environment variable `POWERDNS_SERVER_URL`.

--- a/docs/resources/recordset.md
+++ b/docs/resources/recordset.md
@@ -17,15 +17,13 @@ PowerDNS Zone
 
 ### Required
 
-- **name** (String) Name for record set (e.g. "www.powerdns.com.")
-- **records** (List of String) All records in this record set.
-- **server_id** (String) The id of the server.
-- **ttl** (Number) DNS TTL of the records, in seconds.
-- **type** (String) Type of this record (e.g. "A", "PTR", "MX").
-- **zone_id** (String) ID of the zone this record set belongs to.
+- `name` (String) Name for record set (e.g. "www.powerdns.com.")
+- `records` (List of String) All records in this record set.
+- `server_id` (String) The id of the server.
+- `ttl` (Number) DNS TTL of the records, in seconds.
+- `type` (String) Type of this record (e.g. "A", "PTR", "MX").
+- `zone_id` (String) ID of the zone this record set belongs to.
 
 ### Read-Only
 
-- **id** (String) State ID for the record set (only needed for internal technical purposes).
-
-
+- `id` (String) State ID for the record set (only needed for internal technical purposes).

--- a/docs/resources/zone.md
+++ b/docs/resources/zone.md
@@ -25,12 +25,10 @@ resource "powerdns_zone" "example_org" {
 
 ### Required
 
-- **kind** (String) Zone kind, one of "Native", "Master", "Slave".
-- **name** (String) Name of the zone (e.g. "example.com.") MUST have a trailing dot.
-- **server_id** (String) The id of the server.
+- `kind` (String) Zone kind, one of "Native", "Master", "Slave".
+- `name` (String) Name of the zone (e.g. "example.com.") MUST have a trailing dot.
+- `server_id` (String) The id of the server.
 
 ### Read-Only
 
-- **id** (String) Opaque zone id, assigned by the server.
-
-
+- `id` (String) Opaque zone id, assigned by the server.


### PR DESCRIPTION
The documentation is outdated. Update it by running `go generate`.
