### PR TITLE
Add permissions to write contents to dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -8,6 +8,7 @@ jobs:
     name: Approve
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       pull-requests: write
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:


### PR DESCRIPTION
The `contents: write` permission is needed to merge a PR.
